### PR TITLE
Fixing GET implementation callback-catch bug

### DIFF
--- a/urban-dictionary.js
+++ b/urban-dictionary.js
@@ -31,15 +31,15 @@ function get (url, callback) {
       rawData += buffer
     })
     result.on('end', function () {
-      var data = null;
-      var error = null;
+      var data = null
+      var error = null
       try {
-        data = JSON.parse(rawData);
+        data = JSON.parse(rawData)
       } catch (error) {
-        data = null; //incase somehow data got set to not null, this is more of a failsafe.
-        error = new Error('Failed to parse retrieved Urban Dictionary JSON.');
+        data = null //incase somehow data got set to not null, this is more of a failsafe.
+        error = new Error('Failed to parse retrieved Urban Dictionary JSON.')
       }
-      callback(error, data);
+      callback(error, data)
     })
   })
 }

--- a/urban-dictionary.js
+++ b/urban-dictionary.js
@@ -31,11 +31,15 @@ function get (url, callback) {
       rawData += buffer
     })
     result.on('end', function () {
+      var data = null;
+      var error = null;
       try {
-        callback(null, JSON.parse(rawData))
+        data = JSON.parse(rawData);
       } catch (error) {
-        callback(new Error('Failed to parse retrieved Urban Dictionary JSON.'))
+        data = null; //incase somehow data got set to not null, this is more of a failsafe.
+        error = new Error('Failed to parse retrieved Urban Dictionary JSON.');
       }
+      callback(error, data);
     })
   })
 }


### PR DESCRIPTION
Your current GET function is made in a way that catches all errors within the callback itself as well, this leads to any error within the callback leading to a false error, and a second callback with invalid data.

The new implementation initializes both callback params as null, tries to set the data variable to the Parsed json, and otherwise sets the error to "failed to parse json" as appropriate. 

Feel free to tell me if you want me to change something within the PR.